### PR TITLE
Add dependencies parameters to CompatibilityChecker

### DIFF
--- a/core/src/main/java/com/github/fridujo/retrokompat/CompatibilityChecker.java
+++ b/core/src/main/java/com/github/fridujo/retrokompat/CompatibilityChecker.java
@@ -1,5 +1,7 @@
 package com.github.fridujo.retrokompat;
 
+import static java.util.Collections.emptySet;
+
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -11,8 +13,12 @@ import java.util.stream.Collectors;
 public class CompatibilityChecker {
 
     public Set<CompatibilityError> check(Path v1JarPath, Path v2JarPath) {
-        JarObject v1Jar = new JarObject(v1JarPath);
-        JarObject v2Jar = new JarObject(v2JarPath);
+        return check(v1JarPath, emptySet(), v2JarPath, emptySet());
+    }
+
+    public Set<CompatibilityError> check(Path v1JarPath, Set<Path> v1DependencyPaths, Path v2JarPath, Set<Path> v2DependencyPaths) {
+        JarObject v1Jar = new JarObject(v1JarPath, v1DependencyPaths);
+        JarObject v2Jar = new JarObject(v2JarPath, v2DependencyPaths);
 
         MissingTypes missingTypes = new MissingTypes(v1Jar, v2Jar);
 

--- a/core/src/main/java/com/github/fridujo/retrokompat/tools/Urls.java
+++ b/core/src/main/java/com/github/fridujo/retrokompat/tools/Urls.java
@@ -1,0 +1,16 @@
+package com.github.fridujo.retrokompat.tools;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+
+public class Urls {
+
+    public static URL fromPath(Path path) {
+        try {
+            return path.toUri().toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/test/java/com/github/fridujo/retrokompat/JarObjectTests.java
+++ b/core/src/test/java/com/github/fridujo/retrokompat/JarObjectTests.java
@@ -1,10 +1,16 @@
 package com.github.fridujo.retrokompat;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.github.fridujo.retrokompat.tools.JarMaker;
@@ -29,5 +35,35 @@ class JarObjectTests {
         Set<Signature> signatures = new JarObject(jarPath).extractSignatures();
 
         assertThat(signatures).hasSize(2);
+    }
+
+    @Nested
+    class UsingMavenDependencies {
+
+        private final Path opentest4jPath = getDependencyPath("opentest4j");
+        private final Path junitJupiterApiPath = getDependencyPath("junit-jupiter-api");
+
+        @Test
+        void jarObject_throws_if_class_cannot_be_loaded() {
+            assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> new JarObject(junitJupiterApiPath).streamPublicTypes().collect(Collectors.toList()))
+                .withMessageStartingWith("Cannot load class [")
+                .withMessageEndingWith("] from JAR, maybe a classpath element is missing\n" +
+                    "Consider using JarObject(Path jarPath, Set<Path> dependencyPaths) instead of JarObject(Path jarPath)");
+        }
+
+        @Test
+        void jarObject_works_properly_with_according_classpath() {
+            assertThat(new JarObject(opentest4jPath).streamPublicTypes().map(c -> c.getSimpleName()))
+                .contains("AssertionFailedError");
+        }
+
+        private Path getDependencyPath(String artifactId) {
+            return Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
+                .filter(p -> p.contains(artifactId))
+                .map(Paths::get)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No matching path in classpath"));
+        }
     }
 }


### PR DESCRIPTION
As CompatibilityChecker uses `java.lang.reflect` intensively, it requires classes from given JAR archive to be loadable.