### PR TITLE
Use original declaring class for Method signature

### DIFF
--- a/core/src/main/java/com/github/fridujo/retrokompat/CompatibilityChecker.java
+++ b/core/src/main/java/com/github/fridujo/retrokompat/CompatibilityChecker.java
@@ -65,7 +65,7 @@ public class CompatibilityChecker {
 
     private Set<CompatibilityError> checkExecutableCompatibility(JarObject v1Jar, JarObject v2Jar, MissingTypes missingTypes) {
         Set<Signature> v1Signatures = v1Jar.extractSignatures().stream()
-            .filter(s -> !missingTypes.contains(s.executable.getDeclaringClass()))
+            .filter(s -> !missingTypes.contains(s.originalDeclaringClass))
             .collect(Collectors.toCollection(LinkedHashSet::new));
         Set<Signature> v2Signatures = v2Jar.extractSignatures();
 

--- a/core/src/main/java/com/github/fridujo/retrokompat/JarObject.java
+++ b/core/src/main/java/com/github/fridujo/retrokompat/JarObject.java
@@ -90,7 +90,7 @@ public class JarObject {
         Set<Signature> signatures = new LinkedHashSet<>();
         Arrays.stream(loadedClass.getMethods())
             .filter(m -> m.getDeclaringClass().getClassLoader() != null)
-            .map(Signature::new)
+            .map(executable -> new Signature(loadedClass, executable))
             .forEach(signatures::add);
 
         Arrays.stream(loadedClass.getConstructors())

--- a/core/src/main/java/com/github/fridujo/retrokompat/Signature.java
+++ b/core/src/main/java/com/github/fridujo/retrokompat/Signature.java
@@ -4,19 +4,27 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+import com.github.fridujo.retrokompat.tools.MethodFormatter;
+
 public class Signature {
 
+    public final Class<?> originalDeclaringClass;
     public final Executable executable;
     private final boolean isMethod;
 
     public Signature(Executable executable) {
+        this(executable.getDeclaringClass(), executable);
+    }
+
+    public Signature(Class<?> originalDeclaringClass, Executable executable) {
+        this.originalDeclaringClass = originalDeclaringClass;
         this.executable = executable;
         this.isMethod = executable instanceof Method;
     }
 
     @Override
     public String toString() {
-        return executable.toString();
+        return isMethod ? new MethodFormatter(originalDeclaringClass, (Method) executable).toString() : executable.toString();
     }
 
     /**

--- a/core/src/main/java/com/github/fridujo/retrokompat/tools/MethodFormatter.java
+++ b/core/src/main/java/com/github/fridujo/retrokompat/tools/MethodFormatter.java
@@ -1,0 +1,73 @@
+package com.github.fridujo.retrokompat.tools;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.StringJoiner;
+
+/**
+ * Big old copy of {@link Method#toString()} with the replacement of {@link Method#getDeclaringClass()} by the original
+ * class on which the method had been scanned.
+ */
+public class MethodFormatter {
+
+    private static final int ACCESS_MODIFIERS = Modifier.PUBLIC | Modifier.PROTECTED | Modifier.PRIVATE;
+    public final Class<?> originalDeclaringClass;
+    public final Method method;
+
+    public MethodFormatter(Class<?> originalDeclaringClass, Method method) {
+        this.originalDeclaringClass = originalDeclaringClass;
+        this.method = method;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            StringBuilder sb = new StringBuilder();
+
+            printModifiersIfNonzero(sb, Modifier.methodModifiers(), method.isDefault());
+            specificToStringHeader(sb);
+            sb.append('(');
+            StringJoiner sj = new StringJoiner(",");
+            for (Class<?> parameterType : method.getParameterTypes()) {
+                sj.add(parameterType.getTypeName());
+            }
+            sb.append(sj.toString());
+            sb.append(')');
+
+            if (method.getExceptionTypes().length > 0) {
+                StringJoiner joiner = new StringJoiner(",", " throws ", "");
+                for (Class<?> exceptionType : method.getExceptionTypes()) {
+                    joiner.add(exceptionType.getTypeName());
+                }
+                sb.append(joiner.toString());
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            return "<" + e + ">";
+        }
+    }
+
+    void printModifiersIfNonzero(StringBuilder sb, int mask, boolean isDefault) {
+        int mod = method.getModifiers() & mask;
+
+        if (mod != 0 && !isDefault) {
+            sb.append(Modifier.toString(mod)).append(' ');
+        } else {
+            // Modifier.ACCESS_MODIFIERS
+            int access_mod = mod & ACCESS_MODIFIERS;
+            if (access_mod != 0)
+                sb.append(Modifier.toString(access_mod)).append(' ');
+            if (isDefault)
+                sb.append("default ");
+            mod = (mod & ~ACCESS_MODIFIERS);
+            if (mod != 0)
+                sb.append(Modifier.toString(mod)).append(' ');
+        }
+    }
+
+    void specificToStringHeader(StringBuilder sb) {
+        sb.append(method.getReturnType().getTypeName()).append(' ');
+        sb.append(originalDeclaringClass.getTypeName()).append('.');
+        sb.append(method.getName());
+    }
+}

--- a/core/src/test/java/com/github/fridujo/retrokompat/tools/JarMaker.java
+++ b/core/src/test/java/com/github/fridujo/retrokompat/tools/JarMaker.java
@@ -44,8 +44,10 @@ public class JarMaker {
         StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
         Iterable<? extends JavaFileObject> javaFileObjects = fileManager.getJavaFileObjectsFromPaths(javaFilePaths);
         List<String> options = List.of("-d", outputPath.toString());
-        compiler.getTask(null, fileManager, null, options, null, javaFileObjects)
-            .call();
+        if (!compiler.getTask(null, fileManager, d -> System.out.println(d), options, null, javaFileObjects)
+            .call()) {
+            throw new IllegalStateException("Compilation error");
+        }
         return outputPath;
     }
 

--- a/core/src/test/resources/jar_files/v2/com/github/Dog.java
+++ b/core/src/test/resources/jar_files/v2/com/github/Dog.java
@@ -1,10 +1,12 @@
 package com.github;
 
+import org.opentest4j.AssertionFailedError;
+
 /**
  * Adding a public type is backward compatible.
  * Removing a public type is NOT backward compatible.
  */
-public class Dog implements Animal {
+public class Dog extends AssertionFailedError implements Animal {
 
     @Override
     public void pet() throws NotPettableException {


### PR DESCRIPTION
As `Method#declaringClass` refers to the type that actually defines the
method and not the class that was scanned for method.

In the case of public methods inherited from super class or interfaces,
the compatibility checker needs to know the original class that was
scanned even if some methods are declared in super types.

This is for filtering signatures and displaying them in errors.